### PR TITLE
build: Fix build CI errors.

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Get Dependencies
       run: |
         sudo apt-get install -y python3-setuptools
+        sudo --set-home pip3 install --upgrade pip
         pip3 install -r requirements.txt
 
     - name: Run Unit Tests
@@ -31,7 +32,9 @@ jobs:
       uses: actions/checkout@v2.2.0
 
     - name: Get Dependencies
-      run: pip3 install -r requirements.txt
+      run: |
+        sudo --set-home pip3 install --upgrade pip
+        pip3 install -r requirements.txt
 
     - name: Run Unit Tests
       run: python3 -m unittest -v

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -32,9 +32,7 @@ jobs:
       uses: actions/checkout@v2.2.0
 
     - name: Get Dependencies
-      run: |
-        sudo --set-home pip3 install --upgrade pip
-        pip3 install -r requirements.txt
+      run: pip3 install -r requirements.txt
 
     - name: Run Unit Tests
       run: python3 -m unittest -v


### PR DESCRIPTION
# Summary

There seemed to be build CI errors on the latest Ubuntu and MacOS environments that are fixed by upgrading pip before the build process. It doesn't fix the issue on Windows, but it's a start.

**EDIT**:
The Windows CI build seems to have fixed itself overnight, so this PR fixes _all_ build CI errors.